### PR TITLE
Fix Course Title Equality Checking in Link Parser

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -39,7 +39,9 @@ module.exports = async ({ user, pass, courses, id }) => {
       .map(anchor => {
         return `${anchor.href}`;
       })
-      .filter(text => text.includes(obj.courses))
+      .filter(text => {
+        return text.split('/')[4] === obj.courses;
+      })
       .pop();
   }, obj);
   await page.goto(link);


### PR DESCRIPTION
Change link parser to check for strict equality between course path and course title, ensuring correct URL gets returned.

Resolves #5 